### PR TITLE
feat: ignore toolchains inside `lake-packages`

### DIFF
--- a/Main.lean
+++ b/Main.lean
@@ -34,7 +34,7 @@ def removeDirAllIfExists (fp : FilePath) : IO Unit :=
 
 def isIgnoredDirPath (fp : FilePath) : Bool :=
   if let some dirName := fp.fileName then
-    dirName.startsWith "."
+    dirName = "lake-packages" ∨ dirName.startsWith "."
   else
     false
 

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:nightly-2022-12-02
+leanprover/lean4:v4.2.0


### PR DESCRIPTION
Toolchains inside `lake-packages` are newer used. Therefore the tool should ignore these folders.